### PR TITLE
Replacing substr() with mb_substr() for multibyte characters.

### DIFF
--- a/lib/wrapper.php
+++ b/lib/wrapper.php
@@ -35,7 +35,7 @@ class SageWrapping {
     $this->templates = [$template];
 
     if (self::$base) {
-      $str = substr($template, 0, -4);
+      $str = mb_substr($template, 0, -4);
       array_unshift($this->templates, sprintf($str . '-%s.php', self::$base));
     }
   }

--- a/patterns/blocks/block-media-carousel.php
+++ b/patterns/blocks/block-media-carousel.php
@@ -17,7 +17,7 @@
               <?php if (!empty($intro)): ?>
                 <?php
                   if (strlen($intro) > $excerpt_length):
-                    echo trim(substr($intro, 0, $excerpt_length)) . '&hellip;';
+                    echo trim(mb_substr($intro, 0, $excerpt_length)) . '&hellip;';
                   else:
                     echo $intro;
                   endif;
@@ -25,7 +25,7 @@
               <?php elseif (!empty($body)): ?>
                 <?php
                   if (strlen($body) > $excerpt_length):
-                    echo trim(substr($body, 0, $excerpt_length)) . '&hellip;';
+                    echo trim(mb_substr($body, 0, $excerpt_length)) . '&hellip;';
                   else:
                     echo $body;
                   endif;

--- a/patterns/blocks/block-media.php
+++ b/patterns/blocks/block-media.php
@@ -42,7 +42,7 @@
                 <?php if (!empty($intro)): ?>
                   <?php
                     if (strlen($intro) > $excerpt_length):
-                      echo trim(substr($intro, 0, $excerpt_length)) . '&hellip;';
+                      echo trim(mb_substr($intro, 0, $excerpt_length)) . '&hellip;';
                     else:
                       echo $intro;
                     endif;
@@ -50,7 +50,7 @@
                 <?php elseif (!empty($body)): ?>
                   <?php
                     if (strlen($body) > $excerpt_length):
-                      echo trim(substr($body, 0, $excerpt_length)) . '&hellip;';
+                      echo trim(mb_substr($body, 0, $excerpt_length)) . '&hellip;';
                     else:
                       echo $body;
                     endif;


### PR DESCRIPTION
This fix is for multibyte characters affecting the truncation. This is directly related to #67 and the fix comes from Marian Maxiumciuc. 