### PR TITLE
155 header categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,11 @@ You now have all the necessary dependencies to run the build process.
 
 To use BrowserSync during `gulp watch` you need to update `devUrl` at the bottom of `assets/manifest.json` to reflect your local development hostname.
 
-For example, if your local development URL is `http://alps-wp.dev` you would update the file to read:
+For example, if your local development URL is `http://alps-wp.test` you would update the file to read:
 ```json
 ...
   "config": {
-    "devUrl": "http://alps-wp.dev"
+    "devUrl": "http://alps-wp.test"
   }
 ...
 ```

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -12,6 +12,6 @@
     }
   },
   "config": {
-    "devUrl": "http://alps-wp.dev"
+    "devUrl": "http://alps-wp.test"
   }
 }

--- a/functions.php
+++ b/functions.php
@@ -264,7 +264,13 @@ function adventist_register_required_plugins() {
       'required'           => true, // If false, the plugin is only 'recommended' instead of required.
       'force_activation'   => true, // If true, plugin is activated upon theme activation and cannot be deactivated until theme switch.
       'force_deactivation' => false, // If true, plugin is deactivated upon theme switch, useful for theme-specific plugins.
-    )
+    ),
+    // WordPress SEO
+		array(
+			'name'     => 'WordPress SEO by Yoast',
+			'slug'     => 'wordpress-seo',
+			'required' => false,
+		)
   );
   $config = array(
     'id'           => 'adventist',                 // Unique ID for hashing notices for multiple instances of TGMPA.


### PR DESCRIPTION
Closes #155 

@designerbrent This uses the plugin Yoast, which enables the `primary category` option. Once you enable the plugin, go to a post and you will see an option in the categories list to `make primary`. If a child category is set to primary, then the child will appear as the title and the parent category will appear as the kicker. If a parent category is set to primary, then the parent will appear as the title and the kicker will not display. Also, if yoast is not activated, it will default to use the first category applied. 

Let me know if this works. 