### PR TITLE
Fix carousel images not displaying

### DIFF
--- a/patterns/components/hero-carousel.php
+++ b/patterns/components/hero-carousel.php
@@ -12,7 +12,7 @@
     <div class="carousel__slides js-carousel__single-item">
       <?php
         foreach ($carousel_slides as $slide): setup_postdata($slide);
-        $image = $slide['carousel_image'][0];
+        $image = $slide['carousel_image'];
         $title = $slide['carousel_title'];
         $subtitle = $slide['carousel_subtitle'];
         $description = $slide['carousel_description'];

--- a/patterns/components/hero-carousel__2-column.php
+++ b/patterns/components/hero-carousel__2-column.php
@@ -16,7 +16,7 @@
     <div class="carousel__slides js-carousel__single-item">
       <?php
         foreach ($carousel_slides as $slide): setup_postdata($slide);
-        $image = $slide['carousel_image'][0];
+        $image = $slide['carousel_image'];
         $title = $slide['carousel_title'];
         $subtitle = $slide['carousel_subtitle'];
         $description = $slide['carousel_description'];


### PR DESCRIPTION
In last version (v2.1.7), changes to handle multiple files were made (to support Piklist).

After upgrading to the latest version, the carousel on the church website we're building didn't display any images. 

After some debugging I noticed that the `$image` variable was only the first digit (e.g. when the attachment id was  `62`,  `6` was being used in `wp_get_attachment_image_url`).

Traced it back to the changes introduced recently, removed the fix for both hero-carousel files and the code started working again.

Out of curiosity, I tested how the carousels would behave if multiple attachments were selected in Piklist, and I believe that the last attachment will be displayed in this scenario.

@designerbrent  - would you be able to double check the tiny change, and merge it if you're happy to?

Thank you.