### PR TITLE
#387 Removed Gutenberg requirement

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -110,13 +110,6 @@ add_post_type_support( 'page', 'excerpt' );
  */
 add_action('tgmpa_register', 'adventist_register_required_plugins');
 function adventist_register_required_plugins() {
-    if (get_bloginfo('version') >= '5.0.0') {
-      $plugin_name = 'Gutenberg';
-      $plugin_slug = 'gutenberg';
-      $plugin_required = true;
-      $plugin_activation = true;
-    }
-
     $plugins = array(
       // Guidebook
       array(
@@ -139,12 +132,6 @@ function adventist_register_required_plugins() {
         'slug'              => 'svg-support',
         'required'          => true,
         'force_activation'  => true,
-      ),
-      array(
-        'name'              => $plugin_name,
-        'slug'              => $plugin_slug,
-        'required'          => $plugin_required,
-        'force_activation'  => $plugin_activation,
       ),
   );
 


### PR DESCRIPTION
Closes #387 . You're correct @designerbrent, we don't need the Gutenberg requirement for 5.0 and higher as it is native.