### PR TITLE
Fix: 4-digit Numbers appears on page when adding a 'Footer Logo Icon'

### DIFF
--- a/views/patterns/02-organisms/global/footer.blade.php
+++ b/views/patterns/02-organisms/global/footer.blade.php
@@ -1,5 +1,4 @@
 @php
-  echo carbon_get_theme_option('footer_logo_icon');
   $hide_sabbath = get_alps_option('sabbath_hide');
   $footer_logo = get_alps_option('footer_logo_icon');
   $footer_text = get_alps_option('footer_description');
@@ -46,7 +45,6 @@
     @if ($hide_sabbath == true)
       <div class="l-grid-item--7-col l-grid-item--m--1-col c-footer__logo u-path-fill--white">
         @if ($footer_logo)
-          @php echo $footer_logo @endphp
           <img class="style-svg" src="{{ wp_get_attachment_url($footer_logo) }}" alt="{{ get_post_meta($footer_logo, '_wp_attachment_image_alt', true) }}">
         @else
           @include('patterns.00-atoms.icons.icon-logo-footer')


### PR DESCRIPTION
Closes #429 