### PR TITLE
Add support for Custom Sidebars plugin

### DIFF
--- a/app/Integrations/CustomSidebars.php
+++ b/app/Integrations/CustomSidebars.php
@@ -1,0 +1,17 @@
+<?php
+namespace App\Integrations;
+
+class CustomSidebars {
+    public function init()
+    {
+        add_action('alps_custom_sidebar_widgets', [$this, 'sidebarWidgets']);
+    }
+
+    public function sidebarWidgets()
+    {
+        if (class_exists('CustomSidebarsReplacer')) {
+            $replacer = \CustomSidebarsReplacer::instance();
+            $replacer->replace_sidebars();
+        }
+    }
+}

--- a/functions.php
+++ b/functions.php
@@ -795,3 +795,4 @@ function wpml_language_menu_items(){
 require_once('app/autoloader.php');
 (new App\Core\ALPSVersions())->init();
 (new App\CronScheduler())->init();
+(new App\Integrations\CustomSidebars())->init();

--- a/views/404.blade.php
+++ b/views/404.blade.php
@@ -1,5 +1,9 @@
 @extends('layouts.app')
 @section('content')
+  @php
+    do_action('alps_custom_sidebar_widgets');
+  @endphp
+
   <header class="c-page-header c-page-header__simple u-theme--background-color--dark">
     <div class="c-page-header__simple--inner u-padding">
       <h1 class="u-font--primary--xxl u-color--white">

--- a/views/archive.blade.php
+++ b/views/archive.blade.php
@@ -1,6 +1,8 @@
 @extends('layouts.app')
 @section('content')
   @php
+    do_action('alps_custom_sidebar_widgets');
+
     /**
      * Header data
      */

--- a/views/category.blade.php
+++ b/views/category.blade.php
@@ -1,6 +1,8 @@
 @extends('layouts.app')
 @section('content')
   @php
+    do_action('alps_custom_sidebar_widgets');
+
     $isVisibleSidebar = \App\TemplateHelpers::isVisibleSidebarOnArchive();
 
     $sidebar = [

--- a/views/home.blade.php
+++ b/views/home.blade.php
@@ -1,6 +1,8 @@
 @extends('layouts.app')
 @section('content')
   @php
+    do_action('alps_custom_sidebar_widgets');
+
     if (get_option('show_on_front') === 'posts') {
       /**
        * Home with latest posts

--- a/views/index.blade.php
+++ b/views/index.blade.php
@@ -1,6 +1,8 @@
 @extends('layouts.app')
 @section('content')
   @php
+    do_action('alps_custom_sidebar_widgets');
+
     // Show the sidebar when "index_hide_sidebar"
     $isVisibleSidebar = \App\TemplateHelpers::isVisibleSidebarOnFront();
 

--- a/views/page.blade.php
+++ b/views/page.blade.php
@@ -1,5 +1,8 @@
 @extends('layouts.app')
 @section('content')
+  @php
+    do_action('alps_custom_sidebar_widgets');
+  @endphp
   @while(have_posts())
     {!! the_post() !!}
     @include('patterns.02-organisms.content.content-page')

--- a/views/patterns/02-organisms/content/content-page.blade.php
+++ b/views/patterns/02-organisms/content/content-page.blade.php
@@ -1,5 +1,8 @@
 @php
   global $post;
+
+  do_action('alps_custom_sidebar_widgets');
+
   $cf = get_option('alps_cf_converted');
   $cf_ = '';
   if ($cf) {

--- a/views/single.blade.php
+++ b/views/single.blade.php
@@ -1,5 +1,8 @@
 @extends('layouts.app')
 @section('content')
+  @php
+    do_action('alps_custom_sidebar_widgets');
+  @endphp
   @while(have_posts())
     {!! the_post() !!}
     @include('patterns.02-organisms.content.content-single-'.get_post_type())


### PR DESCRIPTION
The  Custom Sidebars – Dynamic Widget Area Manager uses `wp_head` action to replace the sidebars. Sage theme calls this action after the main template rendering. That's why the old sidebar is showing on pages.

This PR adds a sidebar replacement action call on every page type.