### PR TITLE
Update content-page-full-width.blade.php

### DIFF
--- a/views/patterns/02-organisms/content/content-page-full-width.blade.php
+++ b/views/patterns/02-organisms/content/content-page-full-width.blade.php
@@ -20,7 +20,7 @@
   }
 @endphp
 @include('patterns.02-organisms.sections.page-header-hero')
-<section id="top" class="l-main__content l-grid l-grid--7-col full-width {{ $section_offset }} l-grid-wrap--6-of-7 u-spacing--double--until-xxlarge u-padding--zero--sides">
+<section id="top" class="l-main__content l-grid l-grid--7-col full-width {{ $section_offset }} l-grid-wrap--6-of-7 u-spacing--double--until-xxlarge u-shift--left--1-col--at-xxlarge u-padding--zero--sides">
   <article @php post_class("c-article l-grid-item l-grid-item--l--4-col $article_offset") @endphp>
     <div class="c-article__body">
       <div class="text u-spacing">


### PR DESCRIPTION
I propose to add the attribute "u-shift--left--1-col--at-xxlarge" in the section id="top" div.  This attribute is missing in the original wordpress template on https://www.adventist.io/themes/wordpress/  leading to the initial setup having a shifted section aligned to the far left edge on desktop. Each time I setup a new website I always add that attribute to solve the problem, so best to make changes to the original download.