### PR TITLE
Update automatic assignees on bug_report.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug report
 about: Create a report to help us improve
 title: ''
 labels: bug
-assignees: designerbrent
+assignees: YauheniKapliarchuk,hans-olson
 
 ---
 


### PR DESCRIPTION
This fix removes my name from automatically getting assigned to all new bug reports.