### PR TITLE
Fix alps_convert_plugin() function to check for piklist.zip presence before unlink()

### DIFF
--- a/app/carbon-fields/_init.php
+++ b/app/carbon-fields/_init.php
@@ -131,8 +131,12 @@ if (!$cf) {
                 foreach ($dirs as $dir) {
                     alps_remove_dir_recursively($dir);
                 }
-                // REMOVE THEME SUPPLIED PIKLST
-                unlink(get_template_directory() . '/lib/plugins/piklist.zip');
+
+                // Make sure piklist actually exists before trying to delete it.
+                if (file_exists(get_template_directory() . '/lib/plugins/piklist.zip')) {
+                    // REMOVE THEME SUPPLIED PIKLST
+                    unlink(get_template_directory() . '/lib/plugins/piklist.zip');
+                }
 
                 echo __('<p>Activated.</p> <p style="font-size:26px">The ALPS Fields Converter has run successfully.', 'alps') . '<a href="' . admin_url('plugins.php?action=alps_update_complete') . '">' . __('Click here to return to the plugin management page.', 'alps') . '</a></p>';
             }


### PR DESCRIPTION
This PR adds a check to make sure piklist.zip file exists before doing unlink(). Installing the latest alps theme on a fresh install throws an error because alps_convert_plugin() will try to unlink piklist.zip but piklist plugin was never installed.