### PR TITLE
Fix undefined variable exceptions in header block featured

### DIFF
--- a/resources/views/patterns/01-molecules/blocks/header-block-featured.blade.php
+++ b/resources/views/patterns/01-molecules/blocks/header-block-featured.blade.php
@@ -12,12 +12,13 @@
    * @var string $headerImages
    */
     $mediaBlockTitle = $headerTitle;
-    $mediaBlockTitleLink = $headerTitleLink;
+    $mediaBlockTitleLink = "";
     $mediaBlockDesc = $headerDesc;
     $mediaBlockDate = $headerDate;
     $mediaBlockCategory = $headerCategory;
     $mediaBlockImageCaption = $headerImageCaption;
     $mediaBlockImages = $headerImages;
+    $mediaBlockKicker = "";
 @endphp
 <header class="c-page-header c-page-header__feature">
   <div class="c-page-header__content">


### PR DESCRIPTION
In #538 the header block featured was added with two undefined variables, `$mediaBlockTitleLink` which was assigned the undefined variable `$headerTitleLink`:

https://github.com/adventistchurch/alps-wordpress/blob/77598f35284385044123a9d46b0dbb65a90fb9e5/resources/views/patterns/01-molecules/blocks/header-block-featured.blade.php#L15

and `$mediaBlockKicker` which was used in the media block v2 template without being defined in header block featured:

https://github.com/adventistchurch/alps-wordpress/blob/77598f35284385044123a9d46b0dbb65a90fb9e5/resources/views/patterns/01-molecules/blocks/media-block-v2.blade.php#L42-L44

I believe that the `getPostData($postId)` function in `app/template-helpers.php` returns the data for the header block featured template without including data for either of these variables:

https://github.com/adventistchurch/alps-wordpress/blob/77598f35284385044123a9d46b0dbb65a90fb9e5/app/template-helpers.php#L122-L130

These undefined variables can cause a fatal exception (depending on PHP version):

```
Undefined variable $headerTitleLink (View: .../wp-content/themes/alps-wordpress-v3/resources/views/patterns/01-molecules/blocks/header-block-featured.blade.php)
```

The changes proposed in this PR are only to fix the fatal exceptions without actually addressing the missing variable sources. 