### PR TITLE
627 feature: Add footer localization

### DIFF
--- a/app/carbon-fields/cf-theme-options.php
+++ b/app/carbon-fields/cf-theme-options.php
@@ -58,7 +58,7 @@ function crb_attach_theme_options()
             ->set_html(__('<h3>Global Site Statements</h3><p style="font-size:16px">Both of these statements show up in the navigation drawer.</p>', 'alps')),
         Field
             ::make('textarea', 'site_branding_statement', __('Site Branding Statement', 'alps'))
-            ->set_default_value(__('[Site Name] is a website of the Seventh-day Adventist church in [Region Name].', 'alps'))
+            ->set_default_value(__('An official website of the Seventh-day Adventist Church.', 'alps'))
             ->set_help_text(__('Found in the navigation drawer', 'alps'))
             ->set_rows(2)
             ->set_width(50),
@@ -202,8 +202,34 @@ function crb_attach_theme_options()
         ])
         ->add_tab(__('FOOTER CONTENT', 'alps'), [
             Field
-                ::make('rich_text', 'footer_description', __('Footer Description', 'alps'))
-                ->set_default_value(__('[Site URL/Name] is the official website of the Seventh-day Adventist World church.', 'alps')),
+                ::make( 'complex', 'footer_description', __('Footer Description', 'alps'))
+                    ->add_fields( 'translatable_footer_description', [
+                            Field
+                                ::make('text', 'footer_description_en', __('Footer Description English', 'alps'))
+                                ->set_default_value(__('An official website of the Seventh-day Adventist Church.', 'alps')),
+                            Field
+                                ::make('text', 'footer_description_de', __('Fußzeilenbeschreibung Deutsch', 'alps'))
+                                ->set_default_value(__('Eine offizielle Website der Kirche der Siebenten-Tags-Adventisten.', 'alps')),
+                            Field
+                                ::make('text', 'footer_description_fr', __('Description du Pied de Page Français', 'alps'))
+                                ->set_default_value(__('Un site officiel de l\'Église adventiste du Septième jour.', 'alps')),
+                            Field
+                                ::make('text', 'footer_description_pt-pt', __('Rodapé Descrição Português', 'alps'))
+                                ->set_default_value(__('Um site oficial da Igreja Adventista do Sétimo Dia.', 'alps')),
+                            Field
+                                ::make('text', 'footer_description_es', __('Descripción del Pie de Página en Español', 'alps'))
+                                ->set_default_value(__('Sitio web oficial de la Iglesia Adventista del Séptimo Día.', 'alps')),
+                            Field
+                                ::make('text', 'footer_description_ko', __('바닥 글 설명 한국어', 'alps'))
+                                ->set_default_value(__('제칠 일 안식일 예수 재림 교회의 공식 웹 사이트.', 'alps')),
+                            Field
+                                ::make('text', 'footer_description_ru', __('Описание нижнего колонтитула (Русский)', 'alps'))
+                                ->set_default_value(__('Официальный веб-сайт Церкви адвентистов седьмого дня.', 'alps')),
+                            Field
+                                ::make('text', 'footer_description_zh-hant', __('页脚说明中文', 'alps'))
+                                ->set_default_value(__('基督复临安息日会的官方网站。', 'alps')),
+
+                        ]),
             Field
                 ::make('text', 'footer_copyright', __('Footer Copyright', 'alps'))
                 ->set_default_value(__('General Conference of Seventh-day Adventists', 'alps')),

--- a/app/local/source/_patterns/02-organisms/global/footer.json
+++ b/app/local/source/_patterns/02-organisms/global/footer.json
@@ -12,6 +12,6 @@
   },
 
   "footer": {
-    "text": "Adventist.org is the Official website of the Seventh-day Adventist world church"
+    "text": "An official website of the Seventh-day Adventist Church Adventist.org."
   }
 }

--- a/assets/lang/alps.php
+++ b/assets/lang/alps.php
@@ -199,7 +199,7 @@ __('Grid Lines', 'alps');
 __('Select if you would like show the grid lines.', 'alps');
 __('<h3>Global Site Statements</h3><p style="font-size:16px">Both of these statements show up in the navigation drawer.</p>', 'alps');
 __('Site Branding Statement', 'alps');
-__('[Site Name] is a website of the Seventh-day Adventist church in [Region Name].', 'alps');
+__('An official website of the Seventh-day Adventist Church.', 'alps');
 __('Found in the navigation drawer', 'alps');
 __('Global Branding Statement', 'alps');
 __('Seventh-day Adventists are devoted to helping people understand the Bible to find freedom, healing, and hope in Jesus.', 'alps');

--- a/defaults.php
+++ b/defaults.php
@@ -18,7 +18,7 @@ update_option( '_grid_lines', '' );
 update_option( '_square_buttons', '' );
 
 // Site Branding Statement (Text)
-update_option( '_site_branding_statement', '[Site Name] is a website of the Seventh-day Adventist church in [Region Name].' );
+update_option( '_site_branding_statement', 'An official website of the Seventh-day Adventist Church.' );
 
 // Global Branding Statement (Text)
 update_option( '_global_branding_statement', 'Seventh-day Adventists are devoted to helping people understand the Bible to find freedom, healing, and hope in Jesus.' );
@@ -76,7 +76,7 @@ update_option( '_sabbath_hide', 'false' );
  */
 
 // Footer Description (Text)
-update_option( '_footer_description', '[Site URL/Name] is the official website of the Seventh-day Adventist World Church.' );
+update_option( '_footer_description_en', 'An official website of the Seventh-day Adventist Church.' );
 
 // Footer Copyright (Text)
 update_option( '_footer_copyright', 'General Conference of Seventh-day Adventists' );
@@ -228,4 +228,4 @@ add_action('load-nav-menus.php', 'auto_nav_creation_learn_more');
  */
 
 // Translate Description (Text)
-update_option( '_translate_description', '[Site URL/Name] is the official website of the Seventh-day Adventist World Church.' );
+update_option( '_translate_description', 'An official website of the Seventh-day Adventist World Church.' );

--- a/defaults.php
+++ b/defaults.php
@@ -228,4 +228,4 @@ add_action('load-nav-menus.php', 'auto_nav_creation_learn_more');
  */
 
 // Translate Description (Text)
-update_option( '_translate_description', 'An official website of the Seventh-day Adventist World Church.' );
+update_option( '_translate_description', 'An official website of the Seventh-day Adventist Church.' );

--- a/functions.php
+++ b/functions.php
@@ -55,7 +55,7 @@ require_once __DIR__ . '/defaults-themes.php';
 
 add_editor_style('/resources/styles/editor.css');
 
-define('ALPS_THEME_VERSION', '3.15.0.1');
+define('ALPS_THEME_VERSION', '3.15.1.0');
 define('ALPS_THEME_NAME', 'alps-gutenberg-blocks');
 
 require_once __DIR__ . '/updater.php';
@@ -482,3 +482,79 @@ add_action( 'enqueue_block_assets', function() {
 // TODO: to be test so deep
      wp_enqueue_style( 'alps_builder', get_theme_root_uri().'/'.'alps-wordpress-v3/app/local/alps/css/wp-editor.css', array(), '1.0', 'all' );
  } );
+
+function crb_get_i18n_suffix() {
+    $suffix = '';
+    if ( ! defined( 'ICL_LANGUAGE_CODE' ) ) {
+        return $suffix;
+    }
+    $suffix = '_' . ICL_LANGUAGE_CODE;
+    return $suffix;
+}
+
+function crb_get_i18n_theme_option( $option_name ) {
+    $suffix = crb_get_i18n_suffix();
+    if (!isset( get_alps_option( $option_name )[ $option_name . $suffix ] ) ) {
+        return '';
+    }
+    return get_alps_option( $option_name )[ $option_name . $suffix ];
+}
+
+// Add new field to the Editor Page section 'Page SubTitle'
+// add_action( 'admin_menu', 'page_sub_title_metabox' );
+//
+// function page_sub_title_metabox() {
+//
+// 	add_meta_box(
+// 		'custom_sub_title_filed_in_page_section_id', // metabox ID
+// 		'Page SubTitle', // title
+// 		'page_sub_title_metabox_callback', // callback function
+// 		'page', // add meta box to custom post type (or post types in array)
+// 		'normal', // position (normal, side, advanced)
+// 		'default' // priority (default, low, high, core)
+// 	);
+//
+// }
+//
+// // it is a callback function which actually displays the content of the meta box
+// function page_sub_title_metabox_callback( $post ) {
+//     $page_sub_title = get_post_meta( $post->ID, 'page_sub_title', true );
+//
+//     echo '
+//          <p>
+//             <label for="page_sub_title">Add Page SubTitle</label>
+//             <br />
+//             <input class="widefat" type="text" name="page_sub_title" id="page_sub_title" value="' . esc_attr( $page_sub_title ) . '" size="30" />
+//           </p>
+//     ';
+// }
+//
+// add_action( 'save_post', 'page_sub_title_metabox_save_meta', 10, 2 );
+//
+// function page_sub_title_metabox_save_meta( $post_id, $post ) {
+//
+// 	// check current user permissions
+// 	$post_type = get_post_type_object( $post->post_type );
+//
+// 	if ( ! current_user_can( $post_type->cap->edit_post, $post_id ) ) {
+// 		return $post_id;
+// 	}
+//
+// 	// Do not save the data if autosave
+// 	if ( defined('DOING_AUTOSAVE') && DOING_AUTOSAVE ) {
+// 		return $post_id;
+// 	}
+//
+// 	// define your own post type here
+// 	if( 'page' !== get_post_type() ) {
+// 		return $post_id;
+// 	}
+//
+// 	if( isset( $_POST[ 'page_sub_title' ] ) ) {
+// 		update_post_meta( $post_id, 'page_sub_title', sanitize_text_field( $_POST[ 'page_sub_title' ] ) );
+// 	} else {
+// 		delete_post_meta( $post_id, 'page_sub_title' );
+// 	}
+//
+// 	return $post_id;
+// }

--- a/resources/lang/alps.php
+++ b/resources/lang/alps.php
@@ -199,7 +199,7 @@ __('Grid Lines', 'alps');
 __('Select if you would like show the grid lines.', 'alps');
 __('<h3>Global Site Statements</h3><p style="font-size:16px">Both of these statements show up in the navigation drawer.</p>', 'alps');
 __('Site Branding Statement', 'alps');
-__('[Site Name] is a website of the Seventh-day Adventist church in [Region Name].', 'alps');
+__('An official website of the Seventh-day Adventist Church.', 'alps');
 __('Found in the navigation drawer', 'alps');
 __('Global Branding Statement', 'alps');
 __('Seventh-day Adventists are devoted to helping people understand the Bible to find freedom, healing, and hope in Jesus.', 'alps');

--- a/resources/views/patterns/02-organisms/global/footer.blade.php
+++ b/resources/views/patterns/02-organisms/global/footer.blade.php
@@ -2,7 +2,14 @@
   $hide_sabbath = get_alps_option('sabbath_hide');
   $footer_logo = get_alps_option('footer_logo_icon');
   $footer_logo_type = get_alps_option('footer_logo_type');
-  $footer_text = get_alps_option('footer_description');
+  $footer_text = crb_get_i18n_theme_option( 'footer_description' );
+    if (empty($footer_text)) {
+      if ( empty( get_alps_option('footer_description')['footer_description_en']) ) {
+        $footer_text = 'An official website of the Seventh-day Adventist Church.';
+      } else {
+        $footer_text = get_alps_option('footer_description')['footer_description_en'];
+      }
+    }
   $footer_copyright = get_alps_option('footer_copyright');
 
   // CARBON FIELDS STORES COMPLEX FIELDS WITH A MULTIDIMENSIONAL FORMAT

--- a/resources/views/sections/footer.blade.php
+++ b/resources/views/sections/footer.blade.php
@@ -2,7 +2,14 @@
   $hide_sabbath = get_alps_option('sabbath_hide');
   $footer_logo = get_alps_option('footer_logo_icon');
   $footer_logo_type = get_alps_option('footer_logo_type');
-  $footer_text = get_alps_option('footer_description');
+  $footer_text = crb_get_i18n_theme_option( 'footer_description' );
+    if (empty($footer_text)) {
+      if ( empty( get_alps_option('footer_description')['footer_description_en']) ) {
+        $footer_text = 'An official website of the Seventh-day Adventist World church.';
+      } else {
+        $footer_text = get_alps_option('footer_description')['footer_description_en'];
+      }
+    }
   $footer_copyright = get_alps_option('footer_copyright');
 
   // CARBON FIELDS STORES COMPLEX FIELDS WITH A MULTIDIMENSIONAL FORMAT

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:         ALPS for WordPress
 Theme URI:          https://adventist.io/themes
 Description:        ALPS is the Adventist Living Pattern Library theme based off of the Sage WordPress theme.
-Version:            3.15.0.1
+Version:            3.15.1.1
 Author:             Seventh-day Adventist Church
 Author URI:         https://adventist.io/themes/worpdress
 Text Domain:        alps


### PR DESCRIPTION
Changes:
- update default phrase for footer and statement;
- add new element in "ALPS theme settings" to "Footer" tab;
- add default phrases for different languages;
- increase version of ALPS.

#627-Add-footer-localization