### PR TITLE
Changes to improve image cropping options for related lists

### DIFF
--- a/app/carbon-fields/cf-post-options.php
+++ b/app/carbon-fields/cf-post-options.php
@@ -24,6 +24,22 @@ function setDefaultHeader() {
     return $default;
 }
 
+function setDefaultRelatedImageCrop() {
+    $default = 'square';
+    if (!empty($_GET['post'])){
+        $id = $_GET['post'];
+        $grid = get_post_meta($id,'_related_grid',true);
+        $oldCircle = get_post_meta($id,'_related_image_round',true);
+        if (!empty($oldCircle)){
+            $default = 'circle';
+        }
+        if (!empty($grid)){
+            $default = 'landscape';
+        }
+    }
+    return $default;
+}
+
 add_action('carbon_fields_register_fields', 'crb_page_options');
 function crb_page_options()
 {
@@ -361,22 +377,24 @@ function crb_attach_related_pages()
 			Field
 				::make('checkbox', 'related_image', __('Related Pages Image', 'alps'))
 				->set_option_value('true')
-				->set_help_text(__('Select to display the feature image for the related pages.', 'alps')),
-			Field
-				::make('checkbox', 'related_image_round', __('Related Pages Round Image', 'alps'))
-				->set_option_value('true')
-				->set_help_text(__('Select to make the featured image round.', 'alps'))
-				->set_conditional_logic([
-					'relation' => 'AND',
-					[
-						'field' => 'related_image',
-						'value' => true,
-					],
-					[
-						'field' => 'related_grid',
-						'value' => false,
-					]
-				]),
+				->set_help_text(__('Select to display the feature image for the related pages.', 'alps'))
+                ->set_width(50),
+            Field
+                ::make('radio', 'related_image_crop', __('Related Page Image Cropping', 'alps'))
+                ->add_options([
+                    'square' => __('Square', 'alps'),
+                    'landscape' => __('Landscape', 'alps'),
+                    'portrait' => __('Portrait', 'alps'),
+                    'circle' => __('Circle', 'alps'),
+                ])
+                ->set_default_value('landscape')
+                ->set_conditional_logic([
+                    [
+                        'field' => 'related_image',
+                        'value' => true,
+                    ]
+                ])
+            ->set_width(50),
 		]);
 }
 

--- a/app/carbon-fields/cf-post-options.php
+++ b/app/carbon-fields/cf-post-options.php
@@ -387,7 +387,7 @@ function crb_attach_related_pages()
                     'portrait' => __('Portrait', 'alps'),
                     'circle' => __('Circle', 'alps'),
                 ])
-                ->set_default_value('landscape')
+                ->set_default_value(setDefaultRelatedImageCrop())
                 ->set_conditional_logic([
                     [
                         'field' => 'related_image',

--- a/app/setup.php
+++ b/app/setup.php
@@ -181,6 +181,10 @@ add_image_size('horiz__4x3--s', 500, 375, array('center', 'center'));
 add_image_size('horiz__4x3--m', 700, 600, array('center', 'center'));
 add_image_size('horiz__4x3--l', 900, 700, array('center', 'center'));
 
+// 3:4 crop for portraits.
+add_image_size('vert__3x4--s', 450, 600, array('center', 'center'));
+add_image_size('vert__3x4--m', 600, 800, array('center', 'center'));
+
 // Flexible height
 add_image_size('flex-height--s', 350, 9999);
 add_image_size('flex-height--m', 700, 9999);
@@ -188,7 +192,8 @@ add_image_size('flex-height--l', 900, 9999);
 add_image_size('flex-height--xl', 1100, 9999);
 
 // Square
-add_image_size('thumbnail--s', 200, 200, array('center', 'center'));
+add_image_size('thumbnail--s', 400, 400, array('center', 'center'));
+add_image_size('thumbnail--m', 800, 800, array('center', 'center'));
 
 // Makes image size available in dashboard for Gutenberg blocks.
 add_action('admin_init', function() {

--- a/resources/views/patterns/01-molecules/blocks/media-block.blade.php
+++ b/resources/views/patterns/01-molecules/blocks/media-block.blade.php
@@ -37,7 +37,7 @@
           </style>
         @else
           @if (isset($picture))
-            <picture class="picture">
+            <picture class="picture @if (isset($picture_class)){{ $picture_class }}@endif">
               <!--[if IE 9]><video style="display: none;"><![endif]-->
               @if (isset($image_break_xl))
                 <source srcset="{{ $image_xl }}" media="(min-width: {{ $image_break_xl }}px)">
@@ -58,7 +58,7 @@
   @endif
   <div class="c-media-block__content c-block__content u-spacing @if (isset($block_content_class)){{ $block_content_class }}@endif">
     <div class="u-spacing c-block__group c-media-block__group @if (isset($block_group_class)){{ $block_group_class }}@endif">
-      <div class="u-spacing u-width--100p">
+      <div class="u-spacing u-width--100p @if (isset($block_text_class)){{ $block_text_class }}@endif">
         @if (isset($kicker))
           <h4 class="c-media-block__kicker c-block__kicker @if (isset($block_kicker_class)){{ $block_kicker_class }}@endif">{{ $kicker }}</h4>
         @endif

--- a/resources/views/patterns/02-organisms/sections/related-pages.blade.php
+++ b/resources/views/patterns/02-organisms/sections/related-pages.blade.php
@@ -5,6 +5,7 @@
   $related_grid = get_post_meta($post->ID, $cf_.'related_grid', true);
   $related_image = get_post_meta($post->ID, $cf_.'related_image', true);
   $related_image_round = get_post_meta($post->ID, $cf_.'related_image_round', true);
+  $thumb_crop = get_post_meta($post->ID, '_related_image_crop', true);
 
   if ($related == 'related_top_level')  {
     // Loop of pages for top level pages
@@ -110,29 +111,61 @@
 
           if ($thumb_id) {
             $alt = get_post_meta($thumb_id, '_wp_attachment_image_alt', true);
+            if (!empty($thumb_crop)){
+              switch($thumb_crop){
+                case 'landscape':
+                  $thumb_size = 'horiz__16x9';
+                  break;
+                case 'portrait':
+                  $thumb_size = 'vert__3x4';
+                  break;
+                default:
+                  $thumb_size = 'thumbnail';
+              }
+            }else{
+              $thumb_size = 'thumbnail';
+            }
+            $image_s = wp_get_attachment_image_src($thumb_id, $thumb_size . '--s');
+            $image_m = wp_get_attachment_image_src($thumb_id, $thumb_size . '--m');
+            if ($thumb_crop == 'landscape'){
+              if ($image_m[1] < 800 ) {
+                $image_m = $image_s;
+              }
+            }else{
+              if ($image_m[1] < 600 ) {
+                $image_m = $image_s;
+              }
+            }
+            $image_s = $image_s[0];
+            $image_m = $image_m[0];
+            $image_break_m = "400";
+            if ($related_image_round == "true" || $thumb_crop == 'circle') {
+              if ($related_grid == "true"){
+                $picture_class = "u-round";
+              }else{
+                $block_img_wrap_class = "u-round u-space--left";
+              }
+            }
+            else {
+              $block_img_wrap_class = "";
+            }
             if ($related_grid == "true") {
               $excerpt_length = 35;
-              $thumb_size = 'horiz__16x9';
               $block_class = "c-media-block__stacked c-block__stacked u-space--right u-space--double--bottom";
               $block_content_class = "u-border--left u-theme--border-color--darker--left";
               $picture = true;
-              $image_s = wp_get_attachment_image_src($thumb_id, $thumb_size)[0];
-              $image_m = wp_get_attachment_image_src($thumb_id, $thumb_size . '--s')[0];
-              $image_break_m = "500";
+              if ($related_image_round == "true" || $thumb_crop == 'circle') {
+                $block_img_wrap_class = "u-padding--double--left u-padding--double--right";
+                $block_content_class = "";
+                $block_group_class = "u-flex--align-center";
+                $block_text_class = "u-text-align--center";
+              }
             }
             else {
-              if ($related_image_round == "true") {
-                $block_img_wrap_class = "u-round u-space--left";
-              }
-              else {
-                $block_img_wrap_class = "";
-              }
               $excerpt_length = 55;
-              $thumb_size = 'thumbnail';
-              $thumb_id = get_post_thumbnail_id($id);
-              $image = wp_get_attachment_image_src($thumb_id, $thumb_size . '--s')[0];
+              $image = $image_s;
               if (end(explode(".", $image)) === 'gif') {
-                  $image = wp_get_attachment_image_src($thumb_id, $thumb_size . 'full')[0];
+                $image = wp_get_attachment_image_src($thumb_id, $thumb_size . 'full')[0];
               }
               $block_group_class = "u-flex--justify-start";
               if (!is_active_sidebar('sidebar-page') || get_post_meta($post->ID, 'hide_sidebar', true) == 'true') {

--- a/resources/views/patterns/02-organisms/sections/related-pages.blade.php
+++ b/resources/views/patterns/02-organisms/sections/related-pages.blade.php
@@ -111,7 +111,11 @@
 
           if ($thumb_id) {
             $alt = get_post_meta($thumb_id, '_wp_attachment_image_alt', true);
-            if (!empty($thumb_crop)){
+           $thumb_size = 'thumbnail';
+           if (!empty($thumb_crop)){
+             if ($thumb_crop == 'landscape') $thumb_size = 'horiz__16x9';
+             if ($thumb_crop == 'portrait') $thumb_size = 'vert__3x4';
+           }
               switch($thumb_crop){
                 case 'landscape':
                   $thumb_size = 'horiz__16x9';


### PR DESCRIPTION
These changes mandate the creation of additional image sizes which means that users will need to re-upload images they intend to use for portrait cropping so they can be reprocessed. This also means that there is a minimum image width of 600 pixels in order for WP to create the necessary image sizes for this use. 

I've increased the resolution of thumbnail images as well because these render extremely poorly on high-density screens. 

Let me know if testing reveals issues I've missed.