### PR TITLE
Added lodash.js dependency to carbon fields initialization

### DIFF
--- a/app/carbon-fields/_init.php
+++ b/app/carbon-fields/_init.php
@@ -36,7 +36,7 @@ add_action('admin_enqueue_scripts', 'cf_admin_style');
 // ADD CF JAVASCRIPT
 function cf_admin_js($hook)
 {
-    wp_enqueue_script('cf-admin-js', get_template_directory_uri() . '/app/carbon-fields/cf-admin.js');
+    wp_enqueue_script('cf-admin-js', get_template_directory_uri() . '/app/carbon-fields/cf-admin.js', array('lodash' ));
 }
 
 add_action('admin_enqueue_scripts', 'cf_admin_js');


### PR DESCRIPTION
WordPress 6.4 removed lodash.js from the editing interface. It's still part of the core but has to be instantiated by the theme in order to be used in the editing interface. I've added it to the Carbon Fields initialization script.